### PR TITLE
[Fix]give leader authority to other team members

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,9 +15,21 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
+    end
+  end
+
+  def destroy
+    if current_user == @agenda.user || current_user == @agenda.team.owner
+      @agenda.team.members.each do |team_member|
+        AgendaMailer.agenda_mail(@agenda, @agenda.team, team_member.email).deliver
+      end
+      @agenda.destroy
+      redirect_to dashboard_url, notice: I18n.t('views.messages.delete_agenda')
+    else
+      redirect_to dashboard_url, notice: I18n.t('views.messages.can_not_delete_agenda')
     end
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :do_not_edit_except_for_owner, only: %i[edit update]
 
   def index
     @teams = Team.all
@@ -47,6 +48,19 @@ class TeamsController < ApplicationController
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
   end
 
+  def transfer_owner
+    @user = Assign.find(params[:id]).user
+    @team = Team.friendly.find(params[:team_id])
+    @team.owner_id = @user.id
+    if @team.update(team_params)
+      TeamMailer.team_mail(@user.email, @team).deliver
+      redirect_to @team, notice: I18n.t('views.messages.changed_leader')
+    else
+      flash.now[:error] = I18n.t('views.messages.failed_to_change_leader')
+      render :show
+    end
+  end
+
   private
 
   def set_team
@@ -55,5 +69,11 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def do_not_edit_except_for_owner
+    if @team.owner_id != current_user.id
+      redirect_to team_url, notice: I18n.t('views.messages.cannot_edit_team_information')
+    end
   end
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -3,6 +3,6 @@ class AgendaMailer < ApplicationMailer
     @agenda = agenda
     @team = team
     @email = email
-    mail to: @email, subject: I18n.t('views.messages.mail_delete_agenda')
+    mail to: @email, subject: I18n.t('mails.messages.delete_agenda')
   end
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,8 @@
+class AgendaMailer < ApplicationMailer
+  def agenda_mail(agenda, team, email)
+    @agenda = agenda
+    @team = team
+    @email = email
+    mail to: @email, subject: I18n.t('views.messages.mail_delete_agenda')
+  end
+end

--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -1,0 +1,7 @@
+class TeamMailer < ApplicationMailer
+  def team_mail(email, team)
+    @email = email
+    @team = team
+    mail to: @email, subject: I18n.t('mails.messages.became_team_leader') + "#{@team.name}"
+  end
+end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,4 +1,4 @@
 <h2>"<%= @team.name %>"</h2>
 
 <h4><%= @agenda.title %></h4>
-<p><%= I18n.t('views.messages.mail_delete_agenda') %></p>
+<p><%= I18n.t('mails.messages.delete_agenda') %></p>

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,4 @@
+<h2>"<%= @team.name %>"</h2>
+
+<h4><%= @agenda.title %></h4>
+<p><%= I18n.t('views.messages.mail_delete_agenda') %></p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -34,6 +34,9 @@
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
+                <% if agenda.user_id == current_user.id || agenda.team.owner_id == current_user.id %>
+                  <object><%= link_to I18n.t('views.button.delete') , agenda_path(agenda), method: :delete, data: { confirm: I18n.t("views.messages.confirm") }, style: "border-radius: 5px; margin-left: 10px; padding: 3px; color: white; background-color: #DC3545;" %></object>
+                <% end %>
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>

--- a/app/views/team_mailer/team_mail.html.erb
+++ b/app/views/team_mailer/team_mail.html.erb
@@ -1,0 +1,5 @@
+<h2><%= I18n.t('mails.messages.became_team_leader') + @team.name %></h2>
+
+<h4>team: <%= @team.name %></h4>
+
+<h4>email: <%= @email %></h4>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,8 +10,10 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
-          </div>
+              <% if @team.owner_id == current_user.id %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+              <% end %>
+            </div>
 
           <div class="col-md-8">
             <div>
@@ -41,7 +43,12 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if assign.user_id == current_user.id || assign.team.owner == current_user %>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
+                      <% if @team.owner == current_user && @team.owner != assign.user %>
+                        <td><%= link_to I18n.t('views.button.change_leader'), transfer_owner_team_assign_path(@team, assign), method: :patch, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,9 @@ en:
   views:
     messages:
       create_agenda: 'Successfully created an agenda!'
+      delete_agenda: 'Successfully deleted the agenda!'
+      mail_delete_agenda: 'The agenda is deleted'
+      can_not_delete_agenda: 'Agenda can be deleted only by the team leader or the user who created the agenda.'
       create_article: 'Successfully created an article!'
       update_article: 'Successfully updated the article!'
       assigned: 'Assigned!'
@@ -261,6 +264,7 @@ en:
       edit_profile: 'Edit Profile'
       team_you_belong_to: 'The team you belong to'
       posted_articles: 'List of posted articles'
+      confirm: 'Are you sure?'
     button:
       submit: 'Submit'
       edit: 'Edit'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -217,18 +217,20 @@ en:
     messages:
       create_agenda: 'Successfully created an agenda!'
       delete_agenda: 'Successfully deleted the agenda!'
-      mail_delete_agenda: 'The agenda is deleted'
       can_not_delete_agenda: 'Agenda can be deleted only by the team leader or the user who created the agenda.'
       create_article: 'Successfully created an article!'
       update_article: 'Successfully updated the article!'
       assigned: 'Assigned!'
       failed_to_assign: 'Assignment failed'
       cannot_delete_the_leader: 'The leader cannot be deleted'
+      changed_leader: 'The leader is changed'
+      failed_to_change_leader: 'It is failed to transfer authority'
       cannot_delete_only_a_member: 'This user is only a member of this team and cannot be deleted'
       delete_member: 'The member has been deleted'
       cannot_delete_member_4_some_reason: 'The file could not be deleted for some reason.'
       failed_to_post: 'Failed to post ...'
       create_team: 'Successfully created a team!'
+      cannot_edit_team_information: 'Only team leader can edit team information'
       failed_to_save_team: 'Failed to save...'
       update_team: 'Successfully updated the team!'
       delete_team: 'The team has been deleted'
@@ -271,6 +273,7 @@ en:
       delete: 'Delete'
       create: 'Create'
       invite: 'Invite'
+      change_leader: "Give authority"
     top:
       line1: 'it is an application to share a specific issue (agenda) easily'
       line2: 'for each member separately for each team or agenda'
@@ -278,3 +281,7 @@ en:
       line4: 'and you will not be able to pick it up, so it is an internal application to avoid it'
     common:
       team: 'Team'
+  mails:
+    messages:
+      delete_agenda: 'The agenda is deleted'
+      became_team_leader: 'You are selected as a leader of '

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
   resource :user
   
   resources :teams do
-    resources :assigns, only: %w(create destroy)
+    resources :assigns, only: %w(create destroy) do
+      patch :transfer_owner, on: :member, controller: :teams
+    end
     resources :agendas, shallow: true do
       resources :articles do
         resources :comments

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/team_mailer_preview.rb
+++ b/spec/mailers/previews/team_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/team_mailer
+class TeamMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/team_mailer_spec.rb
+++ b/spec/mailers/team_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TeamMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
issue No #10 
✔️When the leader (owner) of the team goes to the team show page, a "Give authority" button appears right next to the "delete" button of each team members.
✔️Pressing that button changes the leader to the user selected by the team leader.
✔️Add any action into Team Controller to implement "Give authority".
✔️When a team leader is changed, a notification email will be sent to the new leader.
✔️After the processing is completed, jump to the show page of that team (that is, redirect to the same place)
✔️No other suspicious points or errors in application behavior.